### PR TITLE
 Don't attempt automatic reconnect on auth errors

### DIFF
--- a/src/Chinchilla/DefaultConnectionFactory.cs
+++ b/src/Chinchilla/DefaultConnectionFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Authentication;
 using System.Threading;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Exceptions;
@@ -75,8 +76,14 @@ namespace Chinchilla
                 {
                     return connectionFactory.CreateConnection();
                 }
-                catch (BrokerUnreachableException)
+                catch (BrokerUnreachableException ex)
                 {
+                    if (ex.InnerException is AuthenticationException)
+                    {
+                        logger.Error(ex.InnerException);
+                        throw;
+                    }
+
                     logger.DebugFormat("Reconnect attempt {0} failed.", numTries);
                     ++numTries;
                 }


### PR DESCRIPTION
When connection fails, DefaultConnectionFactory shouldn't try to reconnect if the failure was due to an authentication error (e.g. client presented incorrect SSL certificate), as such errors are not transient
