### PR TITLE
Set delivery mode when publishing

### DIFF
--- a/src/Chinchilla.Specifications/Chinchilla.Specifications.csproj
+++ b/src/Chinchilla.Specifications/Chinchilla.Specifications.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Messages\TestRequestMessage.cs" />
     <Compile Include="Messages\TestMessage.cs" />
     <Compile Include="Messages\TestResponseMessage.cs" />
+    <Compile Include="Messages\TransientMessage.cs" />
     <Compile Include="ModelFactorySpecification.cs" />
     <Compile Include="ModelReferenceSpecification.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Chinchilla.Specifications/Messages/TransientMessage.cs
+++ b/src/Chinchilla.Specifications/Messages/TransientMessage.cs
@@ -1,0 +1,7 @@
+﻿namespace Chinchilla.Specifications.Messages
+{
+    public class TransientMessage : ITransient
+    {
+
+    }
+}

--- a/src/Chinchilla.Specifications/PublisherSpecification.cs
+++ b/src/Chinchilla.Specifications/PublisherSpecification.cs
@@ -110,6 +110,9 @@ namespace Chinchilla.Specifications
             It should_set_reply_to = () =>
                 properties.ReplyTo.ShouldEqual("reply-to");
 
+            It should_set_delivery_mode_to_persistent = () =>
+                properties.DeliveryMode.ShouldEqual((byte)2);
+
             static IBasicProperties properties;
         }
 
@@ -148,6 +151,23 @@ namespace Chinchilla.Specifications
             static IBasicProperties properties;
 
             static TestRequestMessage message;
+        }
+
+        [Subject(typeof(Publisher<>))]
+        public class when_creating_properties_with_transient_message : with_basic_properties<Publisher<TransientMessage>>
+        {
+            Establish context = () =>
+                 message = new TransientMessage();
+
+            Because of = () =>
+                properties = Subject.CreateProperties(message);
+
+            It should_set_delivery_mode_to_not_persistent = () =>
+                properties.DeliveryMode.ShouldEqual((byte)1);
+
+            static IBasicProperties properties;
+
+            static TransientMessage message;
         }
 
         public class with_basic_properties<TSubject> : WithSubject<TSubject>

--- a/src/Chinchilla/Chinchilla.csproj
+++ b/src/Chinchilla/Chinchilla.csproj
@@ -65,6 +65,7 @@
     <Compile Include="IPublishReceipt.cs" />
     <Compile Include="IRequester.cs" />
     <Compile Include="ConfirmingPublisher.cs" />
+    <Compile Include="ITransient.cs" />
     <Compile Include="IWorker.cs" />
     <Compile Include="IWorkerPoolWorker.cs" />
     <Compile Include="IWorkersController.cs" />

--- a/src/Chinchilla/ITransient.cs
+++ b/src/Chinchilla/ITransient.cs
@@ -1,0 +1,9 @@
+﻿namespace Chinchilla
+{
+    /// <summary>
+    /// When a message implements ITransient then it will not be persisted to disk
+    /// </summary>
+    public interface ITransient
+    {
+    }
+}

--- a/src/Chinchilla/Publisher.cs
+++ b/src/Chinchilla/Publisher.cs
@@ -106,6 +106,8 @@ namespace Chinchilla
                 defaultProperties.Expiration = formattedExpiration;
             }
 
+            defaultProperties.SetPersistent(!(message is ITransient));
+
             var replyTo = router.ReplyTo();
             if (!string.IsNullOrEmpty(replyTo))
             {


### PR DESCRIPTION
Does this look ok? We could maybe set the default depending on the durability of the IExchange you're publishing to, however in that case we'll need a marker interface to indicate if the message should be persisted. What do you think?

/cc @cocowalla 
