### PR TITLE
Support for rejecting messages

### DIFF
--- a/src/Chinchilla.Integration/Chinchilla.Integration.csproj
+++ b/src/Chinchilla.Integration/Chinchilla.Integration.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Features\Consumers\CapitalizeMessageConsumer.cs" />
     <Compile Include="Features\Consumers\CustomConfigurationConsumer.cs" />
     <Compile Include="Features\Consumers\HelloWorldMessageConsumer.cs" />
+    <Compile Include="Features\SubscriberRejectFeature.cs" />
     <Compile Include="Features\CustomSerializersFeature.cs" />
     <Compile Include="Features\CustomTopologyFeature.cs" />
     <Compile Include="Features\Messages\CapitalizedMessage.cs" />

--- a/src/Chinchilla.Integration/Features/SubscriberRejectFeature.cs
+++ b/src/Chinchilla.Integration/Features/SubscriberRejectFeature.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using Chinchilla.Api;
+using Chinchilla.Integration.Features.Messages;
+using NUnit.Framework;
+
+namespace Chinchilla.Integration.Features
+{
+    [TestFixture]
+    public class SubscribeRejectFeature : WithApi
+    {
+        [Test]
+        public void ShouldRequeueRejectedMessages()
+        {
+            int receivedMessages = 0;
+            using (var bus = Depot.Connect("localhost/integration"))
+            using (bus.Subscribe((HelloWorldMessage hwm, IDeliveryContext ctx) => { receivedMessages++; throw new InvalidOperationException(); },
+                b => b.DeliverUsing<WorkerPoolDeliveryStrategy>(s => s.NumWorkers = 1)
+                      .OnFailure<RejectMessageFailureStrategy>()
+                      .WithPrefetchCount(1)))
+            {
+                bus.Publish(new HelloWorldMessage { Message = "subscribe!" });
+
+                WaitForDelivery();
+
+                var messages = admin.Messages(IntegrationVHost, new Queue("HelloWorldMessage"));
+                Assert.That(receivedMessages, Is.EqualTo(1));
+                Assert.That(messages.Count(), Is.EqualTo(1));
+            }
+        }
+
+        public class RejectMessageFailureStrategy : ISubscriptionFailureStrategy
+        {
+            public void OnFailure(IDelivery delivery, Exception exception)
+            {
+                delivery.Reject(true);
+                Thread.Sleep(5000);
+            }
+        }
+    }
+}

--- a/src/Chinchilla.Specifications/DeliverySpecification.cs
+++ b/src/Chinchilla.Specifications/DeliverySpecification.cs
@@ -88,6 +88,18 @@ namespace Chinchilla.Specifications
                 delivery.HasRegisteredDeliveryListeners.ShouldBeFalse();
         }
 
+        [Subject(typeof(Delivery))]
+        public class when_rejecting_delivery_with_requeue : with_delivery
+        {
+            Because of = () =>
+                delivery.Reject(true);
+
+            It should_notify_delivery_failure_strategy = () =>
+                listener.WasToldTo(s => s.OnReject(delivery, Param.Is(true)));
+
+            It should_clear_registered_deliveries_after_failed = () =>
+                delivery.HasRegisteredDeliveryListeners.ShouldBeFalse();
+        }
         public class with_delivery : WithFakes
         {
             Establish context = () =>

--- a/src/Chinchilla/ActionDeliveryListener.cs
+++ b/src/Chinchilla/ActionDeliveryListener.cs
@@ -20,6 +20,11 @@ namespace Chinchilla
             action();
         }
 
+        public void OnReject(IDelivery delivery, bool requeue)
+        {
+            action();
+        }
+
         public void OnFailed(IDelivery delivery, Exception exception)
         {
             action();

--- a/src/Chinchilla/Delivery.cs
+++ b/src/Chinchilla/Delivery.cs
@@ -68,6 +68,16 @@ namespace Chinchilla
             deliveryListeners.Clear();
         }
 
+        public void Reject(bool requeue)
+        {
+            foreach (var listener in deliveryListeners)
+            {
+                listener.OnReject(this, requeue);
+            }
+
+            deliveryListeners.Clear();
+        }
+
         public void Failed(Exception e)
         {
             foreach (var listener in deliveryListeners)

--- a/src/Chinchilla/IDelivery.cs
+++ b/src/Chinchilla/IDelivery.cs
@@ -55,6 +55,13 @@ namespace Chinchilla
         void Accept();
 
         /// <summary>
+        /// Indicates that this delivery has been rejected and should 
+        /// placed back on the queue
+        /// </summary>
+        /// <param name="requeue">Whether or not to requeue the message</param>
+        void Reject(bool requeue);
+
+        /// <summary>
         /// Called when a delivery fails
         /// </summary>
         /// <param name="e">The exception which caused this failure</param>

--- a/src/Chinchilla/IDeliveryListener.cs
+++ b/src/Chinchilla/IDeliveryListener.cs
@@ -6,6 +6,8 @@ namespace Chinchilla
     {
         void OnAccept(IDelivery delivery);
 
+        void OnReject(IDelivery delivery, bool requeue);
+
         void OnFailed(IDelivery delivery, Exception exception);
     }
 }

--- a/src/Chinchilla/QueueState.cs
+++ b/src/Chinchilla/QueueState.cs
@@ -5,11 +5,12 @@ namespace Chinchilla
     /// </summary>
     public class QueueState
     {
-        public QueueState(string name, long numAcceptedMessages, long numFailedMessages)
+        public QueueState(string name, long numAcceptedMessages, long numFailedMessages, long numRejectedMessages)
         {
             Name = name;
             NumAcceptedMessages = numAcceptedMessages;
             NumFailedMessages = numFailedMessages;
+            NumRejectedMessages = numRejectedMessages;
         }
 
         /// <summary>
@@ -26,5 +27,10 @@ namespace Chinchilla
         /// The number of failed messages processed by this subscription
         /// </summary>
         public long NumFailedMessages { get; private set; }
+
+        /// <summary>
+        /// The number of rejected messages processed by this subscription
+        /// </summary>
+        public long NumRejectedMessages { get; private set; }
     }
 }


### PR DESCRIPTION
First bash at adding support for rejecting messages. Naive first attempt. Current issues:
- Possible requeue true/false scenarios described here: http://www.rabbitmq.com/blog/2010/08/03/well-ill-let-you-go-basicreject-in-rabbitmq/
- Not clear on sensible workflow between Accept/Reject/Failure. Most likely to reject as an action in a  ISubscriptionFailureStrategy? Current behaviour of clearing listeners in DeliveryQueue means this doesn't work
- RabbitMQs can immediately re-delivering the message to the same consumer, so you'd likely want to sleep/pause the consumer. This is also the cause of the test failing currently.
