### PR TITLE
Support for rejecting messages.

### DIFF
--- a/src/Chinchilla.Integration/Chinchilla.Integration.csproj
+++ b/src/Chinchilla.Integration/Chinchilla.Integration.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Features\StateQueryFeature.cs" />
     <Compile Include="Features\SubscribeFeature.cs" />
     <Compile Include="Features\SubscriberFaultFeature.cs" />
+    <Compile Include="Features\SubscriberRejectFeature.cs" />
     <Compile Include="Features\WithApi.cs" />
     <Compile Include="Serializers\ComplexMessage.cs" />
     <Compile Include="Serializers\MessageSerializerTests.cs" />

--- a/src/Chinchilla.Integration/Features/SubscriberRejectFeature.cs
+++ b/src/Chinchilla.Integration/Features/SubscriberRejectFeature.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using Chinchilla.Api;
+using Chinchilla.Integration.Features.Messages;
+using NUnit.Framework;
+
+namespace Chinchilla.Integration.Features
+{
+    [TestFixture]
+    public class SubscribeRejectFeature : WithApi
+    {
+        [Test]
+        public void ShouldRequeueRejectedMessages()
+        {
+            using (var bus = Depot.Connect("localhost/integration"))
+            {
+                bus.Subscribe((HelloWorldMessage hwm) =>
+                {
+                    throw new MessageRejectedException();
+                });
+
+                bus.Publish(new HelloWorldMessage { Message = "subscribe!" });
+
+                WaitForDelivery();
+            }
+
+            var messages = admin.Messages(IntegrationVHost, new Queue("HelloWorldMessage"));
+            Assert.That(messages.Count(), Is.EqualTo(1));
+        }
+    }
+}

--- a/src/Chinchilla.Specifications/DeliverySpecification.cs
+++ b/src/Chinchilla.Specifications/DeliverySpecification.cs
@@ -88,6 +88,19 @@ namespace Chinchilla.Specifications
                 delivery.HasRegisteredDeliveryListeners.ShouldBeFalse();
         }
 
+        [Subject(typeof(Delivery))]
+        public class when_rejecting_delivery_with_requeue : with_delivery
+        {
+            Because of = () =>
+                delivery.Reject(true);
+
+            It should_notify_delivery_failure_strategy = () =>
+                listener.WasToldTo(s => s.OnReject(delivery, Param.Is(true)));
+
+            It should_clear_registered_deliveries_after_failed = () =>
+                delivery.HasRegisteredDeliveryListeners.ShouldBeFalse();
+        }
+
         public class with_delivery : WithFakes
         {
             Establish context = () =>

--- a/src/Chinchilla.Specifications/WorkerPoolWorkerSpecification.cs
+++ b/src/Chinchilla.Specifications/WorkerPoolWorkerSpecification.cs
@@ -160,6 +160,24 @@ namespace Chinchilla.Specifications
         }
 
         [Subject(typeof(WorkerPoolWorker))]
+        public class when_delivering_one_message_that_throws_rejection_exception : with_worker_pool_thread
+        {
+            Establish context = () =>
+            {
+                processor.WhenToldTo(p => p.Process(Param.IsAny<IDelivery>())).Throw(new MessageRejectedException());
+                delivery = An<IDelivery>();
+            };
+
+            Because of = () =>
+                Subject.Deliver(delivery);
+
+            It should_reject_message = () =>
+                delivery.WasToldTo(d => d.Reject(true));
+
+            static IDelivery delivery;
+        }
+
+        [Subject(typeof(WorkerPoolWorker))]
         public class when_pausing : with_worker_pool_thread
         {
             Because of = () =>

--- a/src/Chinchilla/ActionDeliveryListener.cs
+++ b/src/Chinchilla/ActionDeliveryListener.cs
@@ -20,6 +20,11 @@ namespace Chinchilla
             action();
         }
 
+        public void OnReject(IDelivery delivery, bool requeue)
+        {
+            action();
+        }
+
         public void OnFailed(IDelivery delivery, Exception exception)
         {
             action();

--- a/src/Chinchilla/Chinchilla.csproj
+++ b/src/Chinchilla/Chinchilla.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Bus.cs" />
     <Compile Include="ChinchillaException.cs" />
     <Compile Include="ConsumerSubscriber.cs" />
+    <Compile Include="MessageRejectedException.cs" />
     <Compile Include="PublishFailureReason.cs" />
     <Compile Include="DefaultConnectionFactory.cs" />
     <Compile Include="ConnectionString.cs" />

--- a/src/Chinchilla/Delivery.cs
+++ b/src/Chinchilla/Delivery.cs
@@ -68,6 +68,16 @@ namespace Chinchilla
             deliveryListeners.Clear();
         }
 
+        public void Reject(bool requeue)
+        {
+            foreach (var listener in deliveryListeners)
+            {
+                listener.OnReject(this, requeue);
+            }
+
+            deliveryListeners.Clear();
+        }
+
         public void Failed(Exception e)
         {
             foreach (var listener in deliveryListeners)

--- a/src/Chinchilla/DeliveryQueue.cs
+++ b/src/Chinchilla/DeliveryQueue.cs
@@ -20,6 +20,8 @@ namespace Chinchilla
 
         private long numAcceptedMessages;
 
+        private long numRejectedMessages;
+
         private long numFailedMessages;
 
         public DeliveryQueue(
@@ -42,6 +44,11 @@ namespace Chinchilla
             get { return numAcceptedMessages; }
         }
 
+        public long NumRejectedMessages
+        {
+            get { return numRejectedMessages; }
+        }
+
         public long NumFailedMessages
         {
             get { return numFailedMessages; }
@@ -53,6 +60,14 @@ namespace Chinchilla
 
             modelReference.Execute(
                 m => m.BasicAck(delivery.Tag, false));
+        }
+
+        public void OnReject(IDelivery delivery, bool requeue)
+        {
+            Interlocked.Increment(ref numRejectedMessages);
+
+            modelReference.Execute(
+                m => m.BasicNack(delivery.Tag, false, requeue));
         }
 
         public void OnFailed(IDelivery delivery, Exception exception)
@@ -81,7 +96,7 @@ namespace Chinchilla
 
         public QueueState GetState()
         {
-            return new QueueState(Name, NumAcceptedMessages, NumFailedMessages);
+            return new QueueState(Name, NumAcceptedMessages, numRejectedMessages, NumFailedMessages);
         }
 
         public override string ToString()

--- a/src/Chinchilla/IDelivery.cs
+++ b/src/Chinchilla/IDelivery.cs
@@ -55,6 +55,11 @@ namespace Chinchilla
         void Accept();
 
         /// <summary>
+        /// Indicates that this delivery has been processed and was rejected
+        /// </summary>
+        void Reject(bool requeue);
+
+        /// <summary>
         /// Called when a delivery fails
         /// </summary>
         /// <param name="e">The exception which caused this failure</param>

--- a/src/Chinchilla/IDeliveryListener.cs
+++ b/src/Chinchilla/IDeliveryListener.cs
@@ -6,6 +6,8 @@ namespace Chinchilla
     {
         void OnAccept(IDelivery delivery);
 
+        void OnReject(IDelivery delivery, bool requeue);
+
         void OnFailed(IDelivery delivery, Exception exception);
     }
 }

--- a/src/Chinchilla/IDeliveryQueue.cs
+++ b/src/Chinchilla/IDeliveryQueue.cs
@@ -15,6 +15,11 @@ namespace Chinchilla
         long NumAcceptedMessages { get; }
 
         /// <summary>
+        /// The number of messages rejected by this subscription
+        /// </summary>
+        long NumRejectedMessages { get; }
+
+        /// <summary>
         /// The number of failed messages processed by this subscription
         /// </summary>
         long NumFailedMessages { get; }

--- a/src/Chinchilla/MessageRejectedException.cs
+++ b/src/Chinchilla/MessageRejectedException.cs
@@ -1,0 +1,12 @@
+﻿namespace Chinchilla
+{
+    public class MessageRejectedException : ChinchillaException
+    {
+        public MessageRejectedException()
+        {
+            ShouldRequeue = true;
+        }
+
+        public bool ShouldRequeue { get; set; }
+    }
+}

--- a/src/Chinchilla/QueueState.cs
+++ b/src/Chinchilla/QueueState.cs
@@ -5,10 +5,11 @@ namespace Chinchilla
     /// </summary>
     public class QueueState
     {
-        public QueueState(string name, long numAcceptedMessages, long numFailedMessages)
+        public QueueState(string name, long numAcceptedMessages, long numRejectedMessages, long numFailedMessages)
         {
             Name = name;
             NumAcceptedMessages = numAcceptedMessages;
+            NumRejectedMessages = numRejectedMessages;
             NumFailedMessages = numFailedMessages;
         }
 
@@ -21,6 +22,11 @@ namespace Chinchilla
         /// The number of messages accepted by this subscription
         /// </summary>
         public long NumAcceptedMessages { get; private set; }
+
+        /// <summary>
+        /// The number of messages rejected by this subscription
+        /// </summary>
+        public long NumRejectedMessages { get; private set; }
 
         /// <summary>
         /// The number of failed messages processed by this subscription

--- a/src/Chinchilla/Worker.cs
+++ b/src/Chinchilla/Worker.cs
@@ -39,6 +39,10 @@ namespace Chinchilla
                 connectedProcessor.Process(delivery);
                 delivery.Accept();
             }
+            catch (MessageRejectedException e)
+            {
+                delivery.Reject(e.ShouldRequeue);
+            }
             catch (Exception e)
             {
                 delivery.Failed(e);


### PR DESCRIPTION
You can now reject a message by throwing `MessageRejectedException`. I'm not a huge fan of using rejection for flow control, but I think that rejecting messages should be an exceptional thing you do, not something which you'll do _often_. What do you guys think of this?

This doens't solve the fact that a rejected message will be _retried_ instantly with another consumer. If you want to do that you're better off throwing a different exception and using a custom fault handler, which would put something on an error queue with a ttl or something.

/cc @cocowalla 
/cc @jamescrowley
