### PR TITLE
[WIP] Ability to subscribe to interfaces

### DIFF
--- a/src/Chinchilla.Integration/Chinchilla.Integration.csproj
+++ b/src/Chinchilla.Integration/Chinchilla.Integration.csproj
@@ -35,6 +35,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core">
+      <HintPath>..\packages\Castle.Core.3.2.0\lib\net40-client\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
@@ -62,6 +65,7 @@
     <Compile Include="Features\Messages\CapitalizedMessage.cs" />
     <Compile Include="Features\Messages\HelloWorldMessage.cs" />
     <Compile Include="Features\Messages\CapitalizeMessage.cs" />
+    <Compile Include="Features\Messages\IHelloWorldMessage.cs" />
     <Compile Include="Features\PausableWorkersFeature.cs" />
     <Compile Include="Features\PublisherConfirmsFeature.cs" />
     <Compile Include="Features\PublishFeature.cs" />
@@ -72,6 +76,7 @@
     <Compile Include="Features\SubscriberFaultFeature.cs" />
     <Compile Include="Features\SubscriberRejectFeature.cs" />
     <Compile Include="Features\WithApi.cs" />
+    <Compile Include="Features\MessageTypeFactories\CastleMessageTypeFactory.cs" />
     <Compile Include="Serializers\ComplexMessage.cs" />
     <Compile Include="Serializers\MessageSerializerTests.cs" />
     <Compile Include="WithLogging.cs" />

--- a/src/Chinchilla.Integration/Features/MessageTypeFactories/CastleMessageTypeFactory.cs
+++ b/src/Chinchilla.Integration/Features/MessageTypeFactories/CastleMessageTypeFactory.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Castle.DynamicProxy;
+using Chinchilla.Serializers;
+
+namespace Chinchilla.Integration.Features.MessageTypeFactories
+{
+    /// <summary>
+    /// This is an example castle message type factory, do not use this in production code!
+    /// </summary>
+    public class CastleMessageTypeFactory : IMessageTypeFactory
+    {
+        private static readonly ProxyGenerator generator = new ProxyGenerator();
+
+        public Func<object> GetTypeFactory(Type key)
+        {
+            return () => generator.CreateInterfaceProxyWithoutTarget(key, new BasicInterceptor());
+        }
+
+        public class BasicInterceptor : IInterceptor
+        {
+            private readonly Dictionary<string, object> properties = new Dictionary<string, object>();
+
+            public void Intercept(IInvocation invocation)
+            {
+                var methodName = invocation.Method.Name;
+                if (methodName.StartsWith("set_"))
+                {
+                    var propertyName = methodName.Substring(4);
+                    properties[propertyName] = invocation.Arguments[0];
+                    return;
+                }
+
+                if (methodName.StartsWith("get_"))
+                {
+                    var propertyName = methodName.Substring(4);
+                    var value = properties[propertyName];
+                    invocation.ReturnValue = value;
+                    return;
+                }
+
+                throw new ArgumentException("Only works with properties");
+            }
+        }
+    }
+}

--- a/src/Chinchilla.Integration/Features/Messages/HelloWorldMessage.cs
+++ b/src/Chinchilla.Integration/Features/Messages/HelloWorldMessage.cs
@@ -1,6 +1,6 @@
 namespace Chinchilla.Integration.Features.Messages
 {
-    public class HelloWorldMessage : IHasRoutingKey
+    public class HelloWorldMessage : IHasRoutingKey, IHelloWorldMessage
     {
         public string Message { get; set; }
 

--- a/src/Chinchilla.Integration/Features/Messages/IHelloWorldMessage.cs
+++ b/src/Chinchilla.Integration/Features/Messages/IHelloWorldMessage.cs
@@ -1,0 +1,7 @@
+﻿namespace Chinchilla.Integration.Features.Messages
+{
+    public interface IHelloWorldMessage
+    {
+        string Message { get; set; }
+    }
+}

--- a/src/Chinchilla.Integration/packages.config
+++ b/src/Chinchilla.Integration/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="NUnit" version="2.6.2" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.1.5" targetFramework="net45" />
+  <package id="Castle.Core" version="3.2.0" targetFramework="net40" />
 </packages>

--- a/src/Chinchilla.Specifications/Chinchilla.Specifications.csproj
+++ b/src/Chinchilla.Specifications/Chinchilla.Specifications.csproj
@@ -104,6 +104,7 @@
     <Compile Include="RequesterSpecification.cs" />
     <Compile Include="Serializers\JsonMessageSerializerSpecification.cs" />
     <Compile Include="Configuration\SubscriptionConfigurationSpecification.cs" />
+    <Compile Include="Serializers\DefaultMessageTypeFactorySpecification.cs" />
     <Compile Include="SubscriptionFactorySpecification.cs" />
     <Compile Include="SubscriptionSpecification.cs" />
     <Compile Include="TaskDeliveryStrategySpecification.cs" />

--- a/src/Chinchilla.Specifications/Serializers/DefaultMessageTypeFactorySpecification.cs
+++ b/src/Chinchilla.Specifications/Serializers/DefaultMessageTypeFactorySpecification.cs
@@ -1,0 +1,36 @@
+﻿using Chinchilla.Serializers;
+using Machine.Fakes;
+using Machine.Specifications;
+
+namespace Chinchilla.Specifications.Serializers
+{
+    public class DefaultMessageTypeFactorySpecification
+    {
+        [Subject(typeof(DefaultMessageTypeFactory))]
+        public class in_general : WithSubject<DefaultMessageTypeFactory>
+        {
+            It should_not_have_cached_factory_by_default = () =>
+                Subject.HasCachedFactory(typeof(IMagicMessage)).ShouldBeFalse();
+        }
+
+        [Subject(typeof(DefaultMessageTypeFactory))]
+        public class when_getting_interface_instance : WithSubject<DefaultMessageTypeFactory>
+        {
+            Because of = () =>
+                message = (IMagicMessage)Subject.GetTypeFactory(typeof(IMagicMessage))();
+
+            It should_create_magic_message_instance = () =>
+                message.ShouldBeOfType<IMagicMessage>();
+
+            It should_have_cached_create_delegate_for_message_type = () =>
+                Subject.HasCachedFactory(typeof(IMagicMessage)).ShouldBeTrue();
+
+            static IMagicMessage message;
+        }
+
+        public interface IMagicMessage
+        {
+            string Name { get; set; }
+        }
+    }
+}

--- a/src/Chinchilla.Specifications/SubscriptionFactorySpecification.cs
+++ b/src/Chinchilla.Specifications/SubscriptionFactorySpecification.cs
@@ -7,6 +7,16 @@ namespace Chinchilla.Specifications
     public class SubscriptionFactorySpecification
     {
         [Subject(typeof(SubscriptionFactory))]
+        public class in_general : WithSubject<SubscriptionFactory>
+        {
+            It should_get_message_type_name_for_class = () =>
+                Subject.GetMessageTypeName(typeof(MyMessage)).ShouldEqual("MyMessage");
+
+            It should_get_message_type_name_for_interface = () =>
+                Subject.GetMessageTypeName(typeof(IMyMessage)).ShouldEqual("MyMessage");
+        }
+
+        [Subject(typeof(SubscriptionFactory))]
         public class when_creating_subscription : WithSubject<SubscriptionFactory>
         {
             Because of = () =>
@@ -62,5 +72,9 @@ namespace Chinchilla.Specifications
 
             static ISubscription subscription;
         }
+
+        public interface IMyMessage { }
+
+        public class MyMessage : IMyMessage { }
     }
 }

--- a/src/Chinchilla/Chinchilla.csproj
+++ b/src/Chinchilla/Chinchilla.csproj
@@ -83,6 +83,9 @@
     <Compile Include="Receipts.cs" />
     <Compile Include="Requester.cs" />
     <Compile Include="RequesterFactory.cs" />
+    <Compile Include="Serializers\ChinchillaSerializerStrategy.cs" />
+    <Compile Include="Serializers\DefaultMessageTypeFactory.cs" />
+    <Compile Include="Serializers\IMessageTypeFactory.cs" />
     <Compile Include="SimpleJson.cs" />
     <Compile Include="Threading\IThread.cs" />
     <Compile Include="Threading\IThreadFactory.cs" />

--- a/src/Chinchilla/Serializers/ChinchillaSerializerStrategy.cs
+++ b/src/Chinchilla/Serializers/ChinchillaSerializerStrategy.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Chinchilla.Reflection;
+
+namespace Chinchilla.Serializers
+{
+    public class ChinchillaSerializerStrategy : PocoJsonSerializerStrategy
+    {
+        private readonly IMessageTypeFactory messageTypeFactory;
+
+        public ChinchillaSerializerStrategy(IMessageTypeFactory messageTypeFactory)
+        {
+            this.messageTypeFactory = messageTypeFactory;
+        }
+
+        protected override object SerializeEnum(Enum p)
+        {
+            return p.ToString();
+        }
+
+        public override object DeserializeObject(object value, Type type)
+        {
+            var stringValue = value as string;
+
+            if (stringValue != null)
+            {
+                if (type.IsEnum)
+                {
+                    return Enum.Parse(type, stringValue);
+                }
+
+                if (ReflectionUtils.IsNullableType(type))
+                {
+                    var underlyingType = Nullable.GetUnderlyingType(type);
+                    if (underlyingType.IsEnum)
+                    {
+                        return Enum.Parse(underlyingType, stringValue);
+                    }
+                }
+            }
+
+            return base.DeserializeObject(value, type);
+        }
+
+        internal override ReflectionUtils.ConstructorDelegate ContructorDelegateFactory(Type key)
+        {
+            if (!key.IsInterface)
+            {
+                return base.ContructorDelegateFactory(key);
+            }
+
+            var factory = messageTypeFactory.GetTypeFactory(key);
+
+            ReflectionUtils.ConstructorDelegate constructorDelegate = delegate
+            {
+                return factory();
+            };
+
+            return constructorDelegate;
+        }
+    }
+}

--- a/src/Chinchilla/Serializers/DefaultMessageTypeFactory.cs
+++ b/src/Chinchilla/Serializers/DefaultMessageTypeFactory.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+
+namespace Chinchilla.Serializers
+{
+    public class DefaultMessageTypeFactory : IMessageTypeFactory
+    {
+        private const MethodAttributes DuckMethodAttributes =
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig;
+
+        private readonly ConcurrentDictionary<Type, Func<object>> factories = new ConcurrentDictionary<Type, Func<object>>();
+
+        private readonly Lazy<ModuleBuilder> moduleBuilder;
+
+        public DefaultMessageTypeFactory()
+        {
+            moduleBuilder = new Lazy<ModuleBuilder>(GetModuleBuilder);
+        }
+
+        public bool HasCachedFactory(Type type)
+        {
+            return factories.ContainsKey(type);
+        }
+
+        public Func<object> GetTypeFactory(Type interfaceType)
+        {
+            return factories.GetOrAdd(interfaceType, CreateFactory);
+        }
+
+        private ModuleBuilder GetModuleBuilder()
+        {
+            var assemblyName = new AssemblyName { Name = "Chinchilla_DynamicTypes" };
+            var assemblyBuilder = Thread.GetDomain().DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            return assemblyBuilder.DefineDynamicModule("Chinchilla_DynamicTypes");
+        }
+
+        private Func<object> CreateFactory(Type interfaceType)
+        {
+            var typeBuilder = moduleBuilder.Value.DefineType(
+                interfaceType.Name + "_backing",
+                TypeAttributes.Public | TypeAttributes.Class);
+
+            typeBuilder.AddInterfaceImplementation(interfaceType);
+
+            foreach (var interfaceProperty in interfaceType.GetProperties())
+            {
+                CreateProperty(typeBuilder, interfaceProperty);
+            }
+
+            var generatedType = typeBuilder.CreateType();
+
+            var newExpression = Expression.New(generatedType);
+            var lambda = Expression.Lambda(newExpression);
+            return (Func<object>)lambda.Compile();
+        }
+
+        private void CreateProperty(TypeBuilder typeBuilder, PropertyInfo interfaceProperty)
+        {
+            var propertyName = interfaceProperty.Name;
+
+            var field = typeBuilder.DefineField(
+                propertyName,
+                interfaceProperty.PropertyType,
+                FieldAttributes.Private);
+
+            var property = typeBuilder.DefineProperty(
+                propertyName,
+                PropertyAttributes.None,
+                interfaceProperty.PropertyType,
+                new[] { interfaceProperty.PropertyType });
+
+            var getMethodBuilder = typeBuilder.DefineMethod(
+                "get_value",
+                DuckMethodAttributes,
+                interfaceProperty.PropertyType,
+                Type.EmptyTypes);
+
+            var getGenerator = getMethodBuilder.GetILGenerator();
+            getGenerator.Emit(OpCodes.Ldarg_0);
+            getGenerator.Emit(OpCodes.Ldfld, field);
+            getGenerator.Emit(OpCodes.Ret);
+
+            var setMethodBuilder = typeBuilder.DefineMethod(
+                "set_value",
+                DuckMethodAttributes,
+                null,
+                new[] { interfaceProperty.PropertyType });
+
+            var setGenerator = setMethodBuilder.GetILGenerator();
+            setGenerator.Emit(OpCodes.Ldarg_0);
+            setGenerator.Emit(OpCodes.Ldarg_1);
+            setGenerator.Emit(OpCodes.Stfld, field);
+            setGenerator.Emit(OpCodes.Ret);
+
+            property.SetGetMethod(getMethodBuilder);
+            property.SetSetMethod(setMethodBuilder);
+
+            typeBuilder.DefineMethodOverride(getMethodBuilder, interfaceProperty.GetGetMethod());
+            typeBuilder.DefineMethodOverride(setMethodBuilder, interfaceProperty.GetSetMethod());
+        }
+    }
+}

--- a/src/Chinchilla/Serializers/IMessageTypeFactory.cs
+++ b/src/Chinchilla/Serializers/IMessageTypeFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Chinchilla.Serializers
+{
+    /// <summary>
+    /// A message type factory is responsible for creating a function that can return the implementation
+    /// of an interface through a function builder.
+    /// </summary>
+    public interface IMessageTypeFactory
+    {
+        Func<object> GetTypeFactory(Type key);
+    }
+}

--- a/src/Chinchilla/Serializers/JsonMessageSerializer.cs
+++ b/src/Chinchilla/Serializers/JsonMessageSerializer.cs
@@ -1,12 +1,20 @@
-﻿using System;
-using System.Text;
-using Chinchilla.Reflection;
+﻿using System.Text;
 
 namespace Chinchilla.Serializers
 {
     public class JsonMessageSerializer : IMessageSerializer
     {
-        private readonly IJsonSerializerStrategy strategy = new EnumSupportedStrategy();
+        private readonly IJsonSerializerStrategy strategy;
+
+        public JsonMessageSerializer()
+            : this(new DefaultMessageTypeFactory())
+        {
+        }
+
+        public JsonMessageSerializer(IMessageTypeFactory messageTypeFactory)
+        {
+            strategy = new ChinchillaSerializerStrategy(messageTypeFactory);
+        }
 
         public string ContentType
         {
@@ -23,37 +31,6 @@ namespace Chinchilla.Serializers
         {
             var decoded = Encoding.UTF8.GetString(message);
             return SimpleJson.DeserializeObject<Message<T>>(decoded, strategy);
-        }
-
-        public class EnumSupportedStrategy : PocoJsonSerializerStrategy
-        {
-            protected override object SerializeEnum(Enum p)
-            {
-                return p.ToString();
-            }
-
-            public override object DeserializeObject(object value, Type type)
-            {
-                var stringValue = value as string;
-                if (stringValue != null)
-                {
-                    if (type.IsEnum)
-                    {
-                        return Enum.Parse(type, stringValue);
-                    }
-
-                    if (ReflectionUtils.IsNullableType(type))
-                    {
-                        var underlyingType = Nullable.GetUnderlyingType(type);
-                        if (underlyingType.IsEnum)
-                        {
-                            return Enum.Parse(underlyingType, stringValue);
-                        }
-                    }
-                }
-
-                return base.DeserializeObject(value, type);
-            }
         }
     }
 }

--- a/src/Chinchilla/SubscriptionFactory.cs
+++ b/src/Chinchilla/SubscriptionFactory.cs
@@ -28,6 +28,27 @@ namespace Chinchilla
             return Tracked;
         }
 
+        public string GetMessageTypeName(Type type)
+        {
+            var typeName = type.Name;
+
+            if (!type.IsInterface)
+            {
+                return typeName;
+            }
+
+            if (!typeName.StartsWith("I"))
+            {
+                var message = string.Format(
+                    "Cannot use '{0}' as an interface message contract because the message type name doesn't start with 'I'",
+                    typeName);
+
+                throw new NotSupportedException(message);
+            }
+
+            return typeName.Substring(1);
+        }
+
         public ISubscription Create<TMessage>(
             IBus bus,
             ISubscriptionConfiguration configuration,
@@ -40,7 +61,7 @@ namespace Chinchilla
                 messageSerializers,
                 callback);
 
-            var messageType = typeof(TMessage).Name;
+            var messageType = GetMessageTypeName(typeof(TMessage));
 
             var faultStrategy = configuration.BuildFaultStrategy(bus);
 


### PR DESCRIPTION
Sometimes it's not a good idea to subscribe to message implementations because it hinders versioning, this change will allow you to subscribe to a message interface. Right now it will subscribe on a queue which matches the implementation, for example: `IMyMessage` will subscribe on `MyMessage`.

This will only work for the default serializer, other serializers will need to be extended to support this.

/cc @cocowalla 
