### PR TITLE
Custom Publish Headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Pending
 
+ * Custom headers on publish
  * [BUG-#31] [tanir] Fault strategies cause exception when iterating delivery listeners multiple times
 
 # 0.2.1.0

--- a/README.md
+++ b/README.md
@@ -284,6 +284,26 @@ public class CustomRouter : DefaultRouter
 }
 ````
 
+## Custom Headers
+
+RabbitMQ allows you to add custom headers to messages, this can be used to route messages (using header based routing, 
+a feature that is not yet exposed natively in Chinchilla) and also for meta data on messages which you can use in your
+subscription handlers and consumers.
+
+````
+public class CustomHeadersMessage : IHasHeaders
+{
+    public void PopulateHeaders(IDictionary<object, object> headers)
+    {
+        headers.Add("foo1", "bar");
+        headers.Add("foo2", "bar");
+        headers.Add("foo3", "bar");
+        headers.Add("foo4", "bar");
+        headers.Add("foo5", "bar");
+    }
+}
+````
+
 ## Subscribers
 
 There are a few ways to subscribe to messages using Chinchilla, but the easiest way is to call `Subscribe` on an

--- a/src/Chinchilla.Integration/Chinchilla.Integration.csproj
+++ b/src/Chinchilla.Integration/Chinchilla.Integration.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Features\CustomSerializersFeature.cs" />
     <Compile Include="Features\CustomTopologyFeature.cs" />
     <Compile Include="Features\Messages\CapitalizedMessage.cs" />
+    <Compile Include="Features\Messages\CustomHeadersMessage.cs" />
     <Compile Include="Features\Messages\HelloWorldMessage.cs" />
     <Compile Include="Features\Messages\CapitalizeMessage.cs" />
     <Compile Include="Features\Messages\IHelloWorldMessage.cs" />

--- a/src/Chinchilla.Integration/Features/Messages/CustomHeadersMessage.cs
+++ b/src/Chinchilla.Integration/Features/Messages/CustomHeadersMessage.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace Chinchilla.Integration.Features.Messages
+{
+    public class CustomHeadersMessage : IHasHeaders
+    {
+        public void PopulateHeaders(IDictionary<object, object> headers)
+        {
+            headers.Add("key1", "foo");
+            headers.Add("key2", "foo");
+            headers.Add("key3", "foo");
+        }
+    }
+}

--- a/src/Chinchilla.Integration/Features/Messages/HelloWorldMessage.cs
+++ b/src/Chinchilla.Integration/Features/Messages/HelloWorldMessage.cs
@@ -1,21 +1,12 @@
-using System.Collections.Generic;
-
 namespace Chinchilla.Integration.Features.Messages
 {
-    public class HelloWorldMessage : IHasRoutingKey, IHelloWorldMessage, IHasHeaders
+    public class HelloWorldMessage : IHasRoutingKey, IHelloWorldMessage
     {
         public string Message { get; set; }
 
         string IHasRoutingKey.RoutingKey
         {
             get { return "messages." + Message; }
-        }
-
-        public void PopulateHeaders(IDictionary<object, object> headers)
-        {
-            headers.Add("key1", "foo");
-            headers.Add("key2", "foo");
-            headers.Add("key3", "foo");
         }
     }
 }

--- a/src/Chinchilla.Integration/Features/Messages/HelloWorldMessage.cs
+++ b/src/Chinchilla.Integration/Features/Messages/HelloWorldMessage.cs
@@ -1,12 +1,21 @@
+using System.Collections.Generic;
+
 namespace Chinchilla.Integration.Features.Messages
 {
-    public class HelloWorldMessage : IHasRoutingKey, IHelloWorldMessage
+    public class HelloWorldMessage : IHasRoutingKey, IHelloWorldMessage, IHasHeaders
     {
         public string Message { get; set; }
 
         string IHasRoutingKey.RoutingKey
         {
             get { return "messages." + Message; }
+        }
+
+        public void PopulateHeaders(IDictionary<object, object> headers)
+        {
+            headers.Add("key1", "foo");
+            headers.Add("key2", "foo");
+            headers.Add("key3", "foo");
         }
     }
 }

--- a/src/Chinchilla.Integration/Features/PublishFeature.cs
+++ b/src/Chinchilla.Integration/Features/PublishFeature.cs
@@ -133,6 +133,28 @@ namespace Chinchilla.Integration.Features
             }
         }
 
+        [Test]
+        public void ShouldPublishWithCustomHeaders()
+        {
+            int numHeaders = 0;
+
+            using (var bus = Depot.Connect("localhost/integration"))
+            {
+                bus.Subscribe((HelloWorldMessage hwm, IDeliveryContext ctx) =>
+                {
+                    numHeaders = ctx.Delivery.Headers.Count;
+                });
+
+                using (var publisher = bus.CreatePublisher<HelloWorldMessage>())
+                {
+                    publisher.Publish(new HelloWorldMessage());
+                    WaitForDelivery();
+                }
+            }
+
+            Assert.That(numHeaders, Is.EqualTo(3));
+        }
+
         public class CustomRouter : DefaultRouter
         {
             public override string Route<TMessage>(TMessage message)

--- a/src/Chinchilla.Integration/Features/PublishFeature.cs
+++ b/src/Chinchilla.Integration/Features/PublishFeature.cs
@@ -180,11 +180,14 @@ namespace Chinchilla.Integration.Features
 
         public class CustomHeaderStrategy : IHeadersStrategy<HelloWorldMessage>
         {
-            public void PopulateHeaders(HelloWorldMessage message, IDictionary<object, object> headers)
+            public Dictionary<object, object> PopulateHeaders(HelloWorldMessage message)
             {
-                headers.Add("key1", "foo");
-                headers.Add("key2", "foo");
-                headers.Add("key3", "foo");
+                return new Dictionary<object, object>
+                {
+                    {"key1", "foo"},
+                    {"key2", "foo"},
+                    {"key3", "foo"}
+                };
             }
         }
 

--- a/src/Chinchilla.Specifications/Chinchilla.Specifications.csproj
+++ b/src/Chinchilla.Specifications/Chinchilla.Specifications.csproj
@@ -89,6 +89,7 @@
     <Compile Include="IgnoreFaultStrategySpecification.cs" />
     <Compile Include="MessageSerializersSpecification.cs" />
     <Compile Include="Messages\AnotherTestMessage.cs" />
+    <Compile Include="Messages\CustomHeadersMessage.cs" />
     <Compile Include="Messages\TestRequestMessage.cs" />
     <Compile Include="Messages\TestMessage.cs" />
     <Compile Include="Messages\TestResponseMessage.cs" />

--- a/src/Chinchilla.Specifications/Configuration/PublisherConfigurationSpecification.cs
+++ b/src/Chinchilla.Specifications/Configuration/PublisherConfigurationSpecification.cs
@@ -1,4 +1,5 @@
-﻿using Chinchilla.Configuration;
+﻿using System.Collections.Generic;
+using Chinchilla.Configuration;
 using Chinchilla.Specifications.Messages;
 using Chinchilla.Topologies;
 using Machine.Fakes;
@@ -97,6 +98,40 @@ namespace Chinchilla.Specifications.Configuration
                 strategy.ShouldBeOfType<DefaultPublisherFailureStrategy<TestMessage>>();
 
             static IPublisherFailureStrategy<TestMessage> strategy;
+        }
+
+        [Subject(typeof(PublisherConfiguration<>))]
+        public class when_building_with_no_header_strategy : WithSubject<PublisherConfiguration<TestMessage>>
+        {
+            Because of = () =>
+               strategy = Subject.BuildHeaderStrategy();
+
+            It should_create_null_header_strategy = () =>
+                strategy.ShouldBeOfType<NullHeaderStrategy<TestMessage>>();
+
+            static IHeadersStrategy<TestMessage> strategy;
+        }
+
+        [Subject(typeof(PublisherConfiguration<>))]
+        public class when_building_with_header_strategy_instance : WithSubject<PublisherConfiguration<TestMessage>>
+        {
+            Establish context = () =>
+                Subject.WithHeaders(new CustomHeaderStrategy());
+
+            Because of = () =>
+               strategy = Subject.BuildHeaderStrategy();
+
+            It should_create_custom_header_strategy = () =>
+                strategy.ShouldBeOfType<CustomHeaderStrategy>();
+
+            static IHeadersStrategy<TestMessage> strategy;
+        }
+
+        public class CustomHeaderStrategy : IHeadersStrategy<TestMessage>
+        {
+            public void PopulateHeaders(TestMessage message, IDictionary<object, object> headers)
+            {
+            }
         }
 
         public class CustomPublisherFailureStrategy : IPublisherFailureStrategy<TestMessage>

--- a/src/Chinchilla.Specifications/Configuration/PublisherConfigurationSpecification.cs
+++ b/src/Chinchilla.Specifications/Configuration/PublisherConfigurationSpecification.cs
@@ -129,8 +129,9 @@ namespace Chinchilla.Specifications.Configuration
 
         public class CustomHeaderStrategy : IHeadersStrategy<TestMessage>
         {
-            public void PopulateHeaders(TestMessage message, IDictionary<object, object> headers)
+            public Dictionary<object, object> PopulateHeaders(TestMessage message)
             {
+                return null;
             }
         }
 

--- a/src/Chinchilla.Specifications/Messages/CustomHeadersMessage.cs
+++ b/src/Chinchilla.Specifications/Messages/CustomHeadersMessage.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Chinchilla.Specifications.Messages
+{
+    public class CustomHeadersMessage : IHasHeaders
+    {
+        public void PopulateHeaders(IDictionary<object, object> headers)
+        {
+            headers.Add("foo1", "bar");
+            headers.Add("foo2", "bar");
+            headers.Add("foo3", "bar");
+            headers.Add("foo4", "bar");
+            headers.Add("foo5", "bar");
+        }
+    }
+}

--- a/src/Chinchilla.Specifications/PublisherFactorySpecification.cs
+++ b/src/Chinchilla.Specifications/PublisherFactorySpecification.cs
@@ -12,13 +12,16 @@ namespace Chinchilla.Specifications
         public class when_building_publisher : with_publisher_factory
         {
             Because of = () =>
-                Subject.Create<TestMessage>(modelReference, configuration);
+                Subject.Create(modelReference, configuration);
 
             It should_build_router = () =>
                 configuration.WasToldTo(c => c.BuildRouter());
 
             It should_build_fault_strategy = () =>
                 configuration.WasToldTo(c => c.BuildFaultStrategy());
+
+            It should_build_header_strategy = () =>
+                configuration.WasToldTo(c => c.BuildHeaderStrategy());
         }
 
         [Subject(typeof(PublisherFactory))]
@@ -28,7 +31,7 @@ namespace Chinchilla.Specifications
                 configuration.WhenToldTo(c => c.ShouldConfirm).Return(true);
 
             Because of = () =>
-                publisher = Subject.Create<TestMessage>(modelReference, configuration);
+                publisher = Subject.Create(modelReference, configuration);
 
             It should_create_confirming_publisher = () =>
                 publisher.ShouldBeOfType<ConfirmingPublisher<TestMessage>>();
@@ -46,6 +49,7 @@ namespace Chinchilla.Specifications
                 configuration.WhenToldTo(c => c.BuildRouter()).Return(An<IRouter>());
                 configuration.WhenToldTo(c => c.BuildTopology(Param.IsAny<IEndpoint>()))
                     .Return(new MessageTopology { PublishExchange = An<IExchange>() });
+                configuration.WhenToldTo(c => c.BuildHeaderStrategy()).Return(An<IHeadersStrategy<TestMessage>>());
 
                 The<IMessageSerializers>().WhenToldTo(s => s.FindOrDefault(Param.IsAny<string>()))
                     .Return(An<IMessageSerializer>());

--- a/src/Chinchilla.Specifications/PublisherSpecification.cs
+++ b/src/Chinchilla.Specifications/PublisherSpecification.cs
@@ -160,6 +160,26 @@ namespace Chinchilla.Specifications
         }
 
         [Subject(typeof(Publisher<>))]
+        public class when_creating_properties_with_message_with_custom_headers : with_basic_properties<Publisher<CustomHeadersMessage>>
+        {
+            Establish context = () =>
+                 message = new CustomHeadersMessage();
+
+            Because of = () =>
+                properties = Subject.CreateProperties(message);
+
+            It should_set_add_custom_headers = () =>
+                properties.IsHeadersPresent().ShouldBeTrue();
+
+            It should_have_all_custom_headers = () =>
+                properties.Headers.Count.ShouldEqual(5);
+
+            static IBasicProperties properties;
+
+            static CustomHeadersMessage message;
+        }
+
+        [Subject(typeof(Publisher<>))]
         public class when_creating_properties_with_transient_message : with_basic_properties<Publisher<TransientMessage>>
         {
             Establish context = () =>

--- a/src/Chinchilla.Specifications/PublisherSpecification.cs
+++ b/src/Chinchilla.Specifications/PublisherSpecification.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Chinchilla.Specifications.Messages;
 using Machine.Fakes;
 using Machine.Specifications;
@@ -163,7 +164,12 @@ namespace Chinchilla.Specifications
         public class when_creating_properties_with_message_with_custom_headers : with_basic_properties<Publisher<CustomHeadersMessage>>
         {
             Establish context = () =>
-                 message = new CustomHeadersMessage();
+            {
+                message = new CustomHeadersMessage();
+
+                The<IHeadersStrategy<CustomHeadersMessage>>().WhenToldTo(h => h.PopulateHeaders(Param.IsAny<CustomHeadersMessage>()))
+                    .Return(new Dictionary<object, object> { { "foo", "bar" } });
+            };
 
             Because of = () =>
                 properties = Subject.CreateProperties(message);
@@ -172,7 +178,7 @@ namespace Chinchilla.Specifications
                 properties.IsHeadersPresent().ShouldBeTrue();
 
             It should_have_all_custom_headers = () =>
-                properties.Headers.Count.ShouldEqual(5);
+                properties.Headers.Count.ShouldEqual(6);
 
             static IBasicProperties properties;
 

--- a/src/Chinchilla/Chinchilla.csproj
+++ b/src/Chinchilla/Chinchilla.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Bus.cs" />
     <Compile Include="ChinchillaException.cs" />
     <Compile Include="ConsumerSubscriber.cs" />
+    <Compile Include="IHasHeaders.cs" />
     <Compile Include="MessageRejectedException.cs" />
     <Compile Include="PublishFailureReason.cs" />
     <Compile Include="DefaultConnectionFactory.cs" />

--- a/src/Chinchilla/Chinchilla.csproj
+++ b/src/Chinchilla/Chinchilla.csproj
@@ -54,7 +54,9 @@
     <Compile Include="ChinchillaException.cs" />
     <Compile Include="ConsumerSubscriber.cs" />
     <Compile Include="IHasHeaders.cs" />
+    <Compile Include="IHeadersStrategy.cs" />
     <Compile Include="MessageRejectedException.cs" />
+    <Compile Include="NullHeaderStrategy.cs" />
     <Compile Include="PublishFailureReason.cs" />
     <Compile Include="DefaultConnectionFactory.cs" />
     <Compile Include="ConnectionString.cs" />

--- a/src/Chinchilla/Configuration/IPublisherBuilder.cs
+++ b/src/Chinchilla/Configuration/IPublisherBuilder.cs
@@ -61,7 +61,17 @@ namespace Chinchilla.Configuration
         /// Sets a custom publisher failure strategy instance which will be called when publishing
         /// a message fails
         /// </summary>
-        IPublisherBuilder<TMessage> OnFailure<TStrategy>(TStrategy instance)
-            where TStrategy : IPublisherFailureStrategy<TMessage>;
+        IPublisherBuilder<TMessage> OnFailure<TStrategy>(IPublisherFailureStrategy<TMessage> instance);
+
+        /// <summary>
+        /// Sets a custom headers strategy which will be used for applying message headers to outgoing
+        /// </summary>
+        IPublisherBuilder<TMessage> WithHeaders(IHeadersStrategy<TMessage> instance);
+
+        /// <summary>
+        /// Sets a custom headers strategy which will be used for applying message headers to outgoing
+        /// </summary>
+        IPublisherBuilder<TMessage> WithHeaders<TStrategy>(params Action<TStrategy>[] configurations)
+            where TStrategy : IHeadersStrategy<TMessage>, new();
     }
 }

--- a/src/Chinchilla/Configuration/IPublisherConfiguration.cs
+++ b/src/Chinchilla/Configuration/IPublisherConfiguration.cs
@@ -15,5 +15,7 @@ namespace Chinchilla.Configuration
         IRouter BuildRouter();
 
         IPublisherFailureStrategy<TMessage> BuildFaultStrategy();
+
+        IHeadersStrategy<TMessage> BuildHeaderStrategy();
     }
 }

--- a/src/Chinchilla/ConfirmingPublisher.cs
+++ b/src/Chinchilla/ConfirmingPublisher.cs
@@ -15,8 +15,9 @@ namespace Chinchilla
             IMessageSerializer serializer,
             IExchange exchange,
             IRouter router,
+            IHeadersStrategy<TMessage> headerStrategy,
             IPublisherFailureStrategy<TMessage> publisherFailureStrategy)
-            : base(modelReference, serializer, exchange, router)
+            : base(modelReference, serializer, exchange, router, headerStrategy)
         {
             this.publisherFailureStrategy = publisherFailureStrategy;
         }

--- a/src/Chinchilla/IHasHeaders.cs
+++ b/src/Chinchilla/IHasHeaders.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Chinchilla
+{
+    public interface IHasHeaders
+    {
+        void PopulateHeaders(IDictionary<object, object> headers);
+    }
+}

--- a/src/Chinchilla/IHeadersStrategy.cs
+++ b/src/Chinchilla/IHeadersStrategy.cs
@@ -4,6 +4,6 @@ namespace Chinchilla
 {
     public interface IHeadersStrategy<in TMessage>
     {
-        void PopulateHeaders(TMessage message, IDictionary<object, object> headers);
+        Dictionary<object, object> PopulateHeaders(TMessage message);
     }
 }

--- a/src/Chinchilla/IHeadersStrategy.cs
+++ b/src/Chinchilla/IHeadersStrategy.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Chinchilla
+{
+    public interface IHeadersStrategy<in TMessage>
+    {
+        void PopulateHeaders(TMessage message, IDictionary<object, object> headers);
+    }
+}

--- a/src/Chinchilla/NullHeaderStrategy.cs
+++ b/src/Chinchilla/NullHeaderStrategy.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Chinchilla
+{
+    public class NullHeaderStrategy<TMessage> : IHeadersStrategy<TMessage>
+    {
+        public void PopulateHeaders(TMessage message, IDictionary<object, object> headers)
+        {
+            
+        }
+    }
+}

--- a/src/Chinchilla/NullHeaderStrategy.cs
+++ b/src/Chinchilla/NullHeaderStrategy.cs
@@ -4,9 +4,9 @@ namespace Chinchilla
 {
     public class NullHeaderStrategy<TMessage> : IHeadersStrategy<TMessage>
     {
-        public void PopulateHeaders(TMessage message, IDictionary<object, object> headers)
+        public Dictionary<object, object> PopulateHeaders(TMessage message)
         {
-            
+            return null;
         }
     }
 }

--- a/src/Chinchilla/Publisher.cs
+++ b/src/Chinchilla/Publisher.cs
@@ -116,11 +116,17 @@ namespace Chinchilla
                 defaultProperties.Expiration = formattedExpiration;
             }
 
+            var headers = headerStrategy.PopulateHeaders(message);
+
             var hasHeaders = message as IHasHeaders;
             if (hasHeaders != null)
             {
-                var headers = new Dictionary<object, object>();
+                headers = headers ?? new Dictionary<object, object>();
                 hasHeaders.PopulateHeaders(headers);
+            }
+
+            if (headers != null)
+            {
                 defaultProperties.Headers = headers;
             }
 

--- a/src/Chinchilla/Publisher.cs
+++ b/src/Chinchilla/Publisher.cs
@@ -14,6 +14,8 @@ namespace Chinchilla
 
         private readonly IMessageSerializer serializer;
 
+        private IHeadersStrategy<TMessage> headerStrategy;
+
         protected bool disposed;
 
         private long numPublishedMessages;
@@ -22,10 +24,12 @@ namespace Chinchilla
             IModelReference modelReference,
             IMessageSerializer serializer,
             IExchange exchange,
-            IRouter router)
+            IRouter router,
+            IHeadersStrategy<TMessage> headerStrategy)
         {
             this.serializer = Guard.NotNull(serializer, "serializer");
             this.router = Guard.NotNull(router, "router");
+            this.headerStrategy = Guard.NotNull(headerStrategy, "headerStrategy");
 
             ModelReference = Guard.NotNull(modelReference, "modelReference");
             Exchange = Guard.NotNull(exchange, "bindable");

--- a/src/Chinchilla/Publisher.cs
+++ b/src/Chinchilla/Publisher.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using Chinchilla.Topologies.Model;
@@ -109,6 +110,14 @@ namespace Chinchilla
             {
                 var formattedExpiration = timeout.Timeout.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
                 defaultProperties.Expiration = formattedExpiration;
+            }
+
+            var hasHeaders = message as IHasHeaders;
+            if (hasHeaders != null)
+            {
+                var headers = new Dictionary<object, object>();
+                hasHeaders.PopulateHeaders(headers);
+                defaultProperties.Headers = headers;
             }
 
             defaultProperties.SetPersistent(!(message is ITransient));

--- a/src/Chinchilla/PublisherFactory.cs
+++ b/src/Chinchilla/PublisherFactory.cs
@@ -28,6 +28,7 @@ namespace Chinchilla
 
             var router = configuration.BuildRouter();
             var faultStrategy = configuration.BuildFaultStrategy();
+            var headerStrategy = configuration.BuildHeaderStrategy();
 
             var messageSerializer = messageSerializers.FindOrDefault(
                 configuration.ContentType);
@@ -38,12 +39,14 @@ namespace Chinchilla
                     messageSerializer,
                     topology.PublishExchange,
                     router,
+                    headerStrategy,
                     faultStrategy)
                 : new Publisher<TMessage>(
                     modelReference,
                     messageSerializer,
                     topology.PublishExchange,
-                    router);
+                    router,
+                    headerStrategy);
 
             publisher.Start();
 


### PR DESCRIPTION
Messages can now be adorned with an IHeaders interface which gives each
message you publish access to the headers collection on the default
properties.

Todo
- [x] Make this a publisher configuration too, so that you don't need to mark up your objects with interfaces.

This will close #28 

/cc @tanir @cocowalla 
