### PR TITLE
Allow subscriptions to start only once

### DIFF
--- a/src/Chinchilla/Subscription.cs
+++ b/src/Chinchilla/Subscription.cs
@@ -65,6 +65,12 @@ namespace Chinchilla
 
         public void Start()
         {
+            if (IsStarted)
+            {
+                logger.InfoFormat("Subscription already started: {0}", this);
+                return;
+            }
+
             logger.InfoFormat("Starting subscription: {0}", this);
 
             logger.Debug(" -> Building listener thread");


### PR DESCRIPTION
This is minor, but I found myself (foolishly) doing this:

```
var subscriber = bus.Subscribe<Message>(OnMessage, ConfigureSubscription);
subscriber.Start();
```

which leads to bad things (un-acked messages and eventual deadlock - I think).