### PR TITLE
[Bug] AdHoc publish memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# Next
+
+  * Bug fix for memory leak with ad-hoc publishing
+
 # 0.3.12
 
   * Change json serializers to not wrap messages in a Message envelope

--- a/src/Chinchilla.Specifications/PublisherFactorySpecification.cs
+++ b/src/Chinchilla.Specifications/PublisherFactorySpecification.cs
@@ -7,7 +7,7 @@ using Machine.Specifications;
 namespace Chinchilla.Specifications
 {
     [Subject(typeof(PublisherFactory))]
-    class PublisherFactorySpecification : WithSubject<PublisherFactory>
+    public class PublisherFactorySpecification : WithSubject<PublisherFactory>
     {
         static IPublisherConfiguration<TestMessage> configuration;
 

--- a/src/Chinchilla.Specifications/PublisherFactorySpecification.cs
+++ b/src/Chinchilla.Specifications/PublisherFactorySpecification.cs
@@ -58,7 +58,7 @@ namespace Chinchilla.Specifications
             Because of = () =>
                 Subject.Create(reference, configuration).Dispose();
 
-            It should_do = () =>
+            It should_not_be_tracking_publishers = () =>
                 Subject.Tracked.ShouldBeEmpty();
         }
 

--- a/src/Chinchilla/Publisher.cs
+++ b/src/Chinchilla/Publisher.cs
@@ -38,7 +38,6 @@ namespace Chinchilla
 
         public virtual void Start()
         {
-
         }
 
         public IPublishReceipt Publish(TMessage message)
@@ -49,12 +48,10 @@ namespace Chinchilla
 
             if (routingKey == null)
             {
-                var exceptionMessage = string.Format(
-                    "An error occured while trying to publish a message of type {0} because it has a null " +
+                throw new ChinchillaException(
+                    $"An error occured while trying to publish a message of type {typeof(TMessage).Name} because it has a null " +
                     "routing key, this could be because IHasRoutingKey implemented, but the RoutingKey property " +
-                    "returned null.", typeof(TMessage).Name);
-
-                throw new ChinchillaException(exceptionMessage);
+                    "returned null.");
             }
 
             var publishReceipt = ModelReference.Execute(model =>
@@ -127,8 +124,8 @@ namespace Chinchilla
             }
 
             ModelReference.Dispose();
-            disposed = true;
             base.Dispose();
+            disposed = true;
         }
     }
 }

--- a/src/Chinchilla/Publisher.cs
+++ b/src/Chinchilla/Publisher.cs
@@ -128,6 +128,7 @@ namespace Chinchilla
 
             ModelReference.Dispose();
             disposed = true;
+            base.Dispose();
         }
     }
 }

--- a/src/Chinchilla/Trackable.cs
+++ b/src/Chinchilla/Trackable.cs
@@ -13,8 +13,7 @@ namespace Chinchilla
         {
             if (isDisposed)
             {
-                var message = string.Format("Object already disposed: {0}", this);
-                throw new ObjectDisposedException(message);
+                throw new ObjectDisposedException($"Object already disposed: {this}");
             }
 
             isDisposed = true;


### PR DESCRIPTION
The publishers are not being removed from trackable factory on dispose,
this was due to not calling the Dispose method of the trackable (duh).
This affects all publishers, but especially the adhoc publish as this
creates a new publisher on each publish.